### PR TITLE
add typings for the public API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+export function clearAuthorizationCache(): void;
+
+export function createWriteStream(filePath: string): void;
+
+export function makeTree(
+  directoryPath: string,
+  callback: (error: Error | null) => void
+): void;
+
+export function recursiveCopy(
+  sourcePath: string,
+  destinationPath: string,
+  callback: (error: Error | null) => void
+): void;
+
+export function symlink(
+  target: string,
+  filePath: string,
+  callback: (error: Error | null) => void
+): void;
+
+export function unlink(
+  filePath: string,
+  callback: (error: Error | null) => void
+): void;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.7",
   "description": "Manipulate files with escalated privileges",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "standard && mocha"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.7",
   "description": "Manipulate files with escalated privileges",
   "main": "index.js",
-  "typings": "index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && mocha"
   },


### PR DESCRIPTION
I want to port GitHub Desktop to this new API (instead of `runas`) now that we need to jump up to Node 10, and I figure having the TS declarations ship with the package would be of use to others who are consuming this from TS.