### PR TITLE
move mocha to a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "author": "Max Brunsfeld",
   "license": "MIT",
   "dependencies": {
-    "mocha": "^3.5.0",
     "nan": "^2.10.0"
   },
   "devDependencies": {
+    "mocha": "^3.5.0",
     "standard": "^10.0.3",
     "temp": "^0.8.3"
   },


### PR DESCRIPTION
The only usage of `mocha` I could find was in here:

https://github.com/atom/fs-admin/blob/7c8a1bd4317b0049b5da50ac6400762958ad9690/package.json#L7

