### PR TITLE
update signature for Init to align with best practices

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -81,7 +81,7 @@ void SpawnAsAdmin(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Init(Handle<Object> exports) {
+void Init(v8::Local<v8::Object> exports) {
   Nan::SetMethod(exports, "getAuthorizationForm", GetAuthorizationForm);
   Nan::SetMethod(exports, "clearAuthorizationCache", ClearAuthorizationCache);
   Nan::SetMethod(exports, "spawnAsAdmin", SpawnAsAdmin);


### PR DESCRIPTION
Spotted this one while trying to build against Electron `5.0.0-beta.8` (which is targeting Node 12 that hasn't shipped quite yet):

```shellsession
../src/main.cc:84:6: error: variable has incomplete type 'void'
void Init(Handle<Object> exports) {
     ^
../src/main.cc:84:11: error: use of undeclared identifier 'Handle'
void Init(Handle<Object> exports) {
          ^
../src/main.cc:84:18: error: 'Object' does not refer to a value
void Init(Handle<Object> exports) {
                 ^
/Users/shiftkey/.node-gyp/5.0.0-beta.8/include/node/v8.h:3257:17: note: declared here
class V8_EXPORT Object : public Value {
                ^
../src/main.cc:84:26: error: use of undeclared identifier 'exports'
void Init(Handle<Object> exports) {
                         ^
../src/main.cc:84:34: error: expected ';' after top level declarator
void Init(Handle<Object> exports) {
                                 ^
                                 ;
```

I borrowed the right signature from `keytar`, which should work fine for previous versions of V8: