### PR TITLE
Implement `createWriteStream` for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,45 @@ Perform file system operations with administrator privileges.
 npm install fs-admin
 ```
 
+## Packaging (Linux only)
+
+This library uses [PolicyKit](https://wiki.archlinux.org/index.php/Polkit) to escalate privileges when calling `createWriteStream(path)` on Linux. In particular, it will invoke `pkexec dd of=path` to stream the desired bytes into the specified location.
+
+### PolicyKit
+
+Not all Linux distros may include PolicyKit as part of their standard installation. As such, it is recommended to make it an explicit dependency of your application package. The following is an example Debian control file that requires `policykit-1` to be installed as part of `my-application`:
+
+```
+Package: my-application
+Version: 1.0.0
+Depends: policykit-1
+```
+
+### Policies
+
+When using this library as part of a Linux application, you may want to install a [Policy](https://wiki.archlinux.org/index.php/PolicyKit#Actions) as well. Although not mandatory, policy files allow customizing the behavior of `pkexec` by e.g., displaying a custom password prompt or retaining admin privileges for a short period of time:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>Your Application Name</vendor>
+  <action id="my-application.pkexec.dd">
+    <description gettext-domain="my-application">Admin privileges required</description>
+    <message gettext-domain="my-application">Please enter your password to save this file</message>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/dd</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+    <defaults>
+      <allow_any>auth_admin_keep</allow_any>
+      <allow_inactive>auth_admin_keep</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+</policyconfig>
+```
+
+Policy files should be installed in `/usr/share/polkit-1/actions` as part of your application's installation script.
+
+For more information, you can find a complete example of requiring PolicyKit and distributing policy files in the [Atom repository](https://github.com/atom/atom/pull/19412).

--- a/test/fs-admin.test.js
+++ b/test/fs-admin.test.js
@@ -7,10 +7,6 @@ const fsAdmin = require('..')
 // Comment this out to test with actual privilege escalation.
 fsAdmin.testMode = true
 
-if (process.platform !== 'win32' && process.platform !== 'darwin') {
-  process.exit(0)
-}
-
 describe('fs-admin', function () {
   let dirPath, filePath
 
@@ -23,7 +19,7 @@ describe('fs-admin', function () {
   if (!fsAdmin.testMode) this.timeout(10000)
 
   describe('createWriteStream', () => {
-    if (process.platform !== 'darwin') return
+    if (process.platform === 'win32') return
 
     it('writes to the given file as the admin user', (done) => {
       fs.writeFileSync(filePath, '')
@@ -74,6 +70,8 @@ describe('fs-admin', function () {
   })
 
   describe('makeTree', () => {
+    if (process.platform === 'linux') return
+
     it('creates a directory at the given path as the admin user', (done) => {
       const pathToCreate = path.join(dirPath, 'dir1', 'dir2', 'dir3')
 
@@ -92,6 +90,8 @@ describe('fs-admin', function () {
   })
 
   describe('unlink', () => {
+    if (process.platform === 'linux') return
+
     it('deletes the given file as the admin user', (done) => {
       fs.writeFileSync(filePath, '')
 
@@ -126,6 +126,8 @@ describe('fs-admin', function () {
   })
 
   describe('symlink', () => {
+    if (process.platform === 'linux') return
+
     it('creates a symlink at the given path as the admin user', (done) => {
       fsAdmin.symlink(__filename, filePath, (error) => {
         assert.strictEqual(error, null)
@@ -141,6 +143,8 @@ describe('fs-admin', function () {
   })
 
   describe('recursiveCopy', () => {
+    if (process.platform === 'linux') return
+
     it('copies the given folder to the given location as the admin user', (done) => {
       const sourcePath = path.join(dirPath, 'src-dir')
       fs.mkdirSync(sourcePath)


### PR DESCRIPTION
This pull request relies on [Polkit](https://wiki.archlinux.org/index.php/Polkit) to stream bytes into a file with administrator privileges. In particular it will use the `pkexec` command to invoke `dd` as an administrator, which in turn will display an authentication message similar to the following:

<p align="center">
<img width="515" alt="Screen Shot 2019-05-28 at 13 39 57" src="https://user-images.githubusercontent.com/482957/58475388-19b16880-814e-11e9-9ec3-14fed50669a7.png"></p>

Users of `fs-admin` can customize this behavior by writing an appropriate `.policy` file in `/usr/share/polkit-1/actions`. Atom, for example, will include an `atom.policy` file that will display a custom message as well as retaining admin access to `dd` for a short period of time. See https://github.com/atom/atom/pull/19412 for more information.