### PR TITLE
ensure CI also builds tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ script:
 branches:
   only:
     - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ deploy: off
 
 branches:
   only:
-    - master
+    - /master|^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
Following on from #13, this ensures the CI providers also build any tags pushed when publishing to NPM. This ensures the prebuild assets are generated and uploaded to create a GitHub release.