### PR TITLE
move rebuild command out to separate step to restore codeql workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,9 @@ jobs:
 
     # Setup dependencies (and build native modules from source)
     - name: Install dependencies
-      run: npm install
+      run: |
+        npm install
+        npm run build
 
     # Run code analysis
     - name: Perform CodeQL Analysis

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "standard && mocha",
-    "install": "prebuild-install || node-gyp rebuild",
+    "install": "prebuild-install || npm run build",
+    "build": "node-gyp rebuild",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 14.0.0 -t 15.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
     "prebuild-electron": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron --strip",


### PR DESCRIPTION
Similar change to https://github.com/atom/node-keytar/pull/333 to fix these failing CodeQL runs

 - https://github.com/atom/fs-admin/actions/runs/396260911
 - https://github.com/atom/fs-admin/actions/runs/403223825