### PR TITLE
run CodeQL on pull_request events

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,6 @@
 name: "Code Scanning - Action"
 
-on:
-  push:
-  schedule:
-    - cron: '0 0 * * 0'
+on: pull_request
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
Addressing this warning from the CodeQL workflow:

> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.