### PR TITLE
Use Boolean instead of Number in `SpawnAsAdmin` return values

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -77,11 +77,11 @@ Napi::Value SpawnAsAdmin(const Napi::CallbackInfo& info) {
 
   void *child_process = StartChildProcess(command, args, test_mode);
   if (!child_process) {
-    return Napi::Number::New(env, false);
+    return Napi::Boolean::New(env, false);
   } else {
     auto worker = new Worker(info[3].As<Napi::Function>(), child_process, test_mode);
     worker->Queue();
-    return Napi::Number::New(env, true);
+    return Napi::Boolean::New(env, true);
   }
 }
 


### PR DESCRIPTION
I just noticed N-API provides a `Boolean` abstraction, which maps to `boolean` values (`true` / `false`) in Javascript instead of using `number` values (`1` / `0`) when using the `Number` abstraction.

This shouldn't affect anything, because the function `spawnAsAdmin` was used only with truthy/falsy checks.